### PR TITLE
Fix typo in index header

### DIFF
--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -15,7 +15,7 @@
     {% endif %}
 
     <section class="accueil-intro">
-        <h1>Des parents engagés pour une école vivante et exigente</h1>
+        <h1>Des parents engagés pour une école vivante et exigeante</h1>
         <p class="intro-texte">
             L’Association des parents soutient activement la vie scolaire en organisant des activités conviviales et en participant aux projets pédagogiques.
         </p>


### PR DESCRIPTION
## Summary
- correct spelling in index heading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3ec66e30832f80374c7da54620b4